### PR TITLE
Fixed double A press in temp flags

### DIFF
--- a/src/menus/temp_flags_menu.cpp
+++ b/src/menus/temp_flags_menu.cpp
@@ -94,7 +94,7 @@ void render_area_flags(Font& font, Cursor cursor) {
 			    	bit_index++;
 			    }
 		    }
-			if (button_is_pressed(Controller::A)) {
+			if (current_input == 256 && a_held == false) {
 				switch (bit_index) {
                     case 7: {
                         tp_gameInfo.temp_flags.flags[i] ^= (1 << 7);
@@ -187,8 +187,9 @@ void TempFlagsMenu::render(Font& font) {
         init_once = true;
     } 
 
-    if (current_input == 256 && a_held == false) {
+    if (!DungeonFlags[cursor.y].line_selected && current_input == 256 && a_held == false) {
         DungeonFlags[cursor.y].line_selected = true;
+		current_input = 0;
         lock_cursor_y = true;
     }
 


### PR DESCRIPTION
When we selected a line in temp flags, the bit on which we start is automatically flipped. This commit fixes that.