### PR TITLE
Fixed double button press in scene menu + card load bypass

### DIFF
--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -37,6 +37,12 @@ void init() {
 void game_loop() {
     using namespace Controller::Pad;
     
+    // Button combo to bypass the automatic loading of the save file
+    // in case of crash cause by the load.
+    if (tp_mPadStatus.sval == (L | R | B) && card_load) {
+        card_load = false;
+    }
+
     // check and load gz settings card if found
     Utilities::load_gz_card(card_load);
 

--- a/src/menus/scene_menu.cpp
+++ b/src/menus/scene_menu.cpp
@@ -54,44 +54,8 @@ void SceneMenu::render(Font& font) {
     sprintf(lines[TIME_HOURS_INDEX].line, "time (hrs):        <%d>", current_hour);
     sprintf(lines[TIME_MINUTES_INDEX].line, "time (mins):       <%d>", current_minute);
 
-    switch (cursor.y) {
-        case TIME_HOURS_INDEX: {
-            if (button_is_pressed(Controller::DPAD_RIGHT)) {
-                tp_gameInfo.raw_game_time += 15.0f;
-                if (tp_gameInfo.raw_game_time >= 360.0f) {
-                    tp_gameInfo.raw_game_time = 0.0f;
-                }
-            } else if (button_is_pressed(Controller::DPAD_LEFT)) {
-                if ((tp_gameInfo.raw_game_time - 15.0f) > 0) {
-                    tp_gameInfo.raw_game_time -= 15.0f;
-                } else {
-                    tp_gameInfo.raw_game_time = 359.75f;
-                }
-                //tp_gameInfo.raw_game_time -= 15.0f;
-            }
-            break;
-        }
-        case TIME_MINUTES_INDEX: {
-            if (button_is_pressed(Controller::DPAD_RIGHT)) {
-                tp_gameInfo.raw_game_time += 0.25f;
-                if (tp_gameInfo.raw_game_time >= 360.0f) {
-                    tp_gameInfo.raw_game_time = 0.0f;
-                }
-            } else if (button_is_pressed(Controller::DPAD_LEFT)) {
-                if (tp_gameInfo.raw_game_time > 0) {
-                    tp_gameInfo.raw_game_time -= 0.25f;
-                } else {
-                    tp_gameInfo.raw_game_time = 359.75f;
-                }
-            }
-            break;
-        }
-    }
-    
-    
     Utilities::move_cursor(cursor, LINES);
     Utilities::render_lines(font, lines, cursor.y, LINES, 160.0f);
-
     
     if (current_input == 256 && a_held == false) {
         SceneItems[cursor.y].active = !SceneItems[cursor.y].active;


### PR DESCRIPTION
- Fixed double increment/decrement of the time on the scene menu
- Added a button combo to bypass the card load in case someone crashes when loading.