### PR TITLE
Fixed commands not saved

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -1,18 +1,22 @@
 #pragma once
 #include <stdint.h>
 
+#define COMMANDS_AMNT 8
+
 extern bool reload_area_flag;
+
+extern bool commands_states[COMMANDS_AMNT];
 
 namespace Commands {
     enum Commands {
-        STORE_POSITION = 0,
-        LOAD_POSITION = 1,
-        MOON_JUMP = 2,
-        RELOAD_AREA = 3,
-        TIMER_TOGGLE = 4,
-        TIMER_RESET = 5,
-        GORGE_VOID = 6,
-        FREE_CAM = 7
+        CMD_STORE_POSITION = 0,
+        CMD_LOAD_POSITION = 1,
+        CMD_MOON_JUMP = 2,
+        CMD_RELOAD_AREA = 3,
+        CMD_TIMER_TOGGLE = 4,
+        CMD_TIMER_RESET = 5,
+        CMD_GORGE_VOID = 6,
+        CMD_FREE_CAM = 7
     };
 
     void process_inputs();

--- a/include/menu.h
+++ b/include/menu.h
@@ -3,6 +3,7 @@
 #include "timer.h"
 #include "input_viewer.h"
 #include "cheats.h"
+#include "commands.h"
 #include "libtp_c/include/utils.h"
 #include <string.h>
 

--- a/include/saves.h
+++ b/include/saves.h
@@ -7,7 +7,7 @@
 #include "menus/memory_menu.h"
 
 #define GZ_SAVE_VERSION_NUMBER 0
-#define GZ_SAVE_ENTRIES_AMNT 8
+#define GZ_SAVE_ENTRIES_AMNT 9
 
 // These numbers can only change when we change the GZ_SAVE_VERSION_NUMBER,
 // otherwise, only new entries can be added.
@@ -20,6 +20,7 @@ enum GZSaveIndex {
     SV_DROP_SHADOW_INDEX = 5,
     SV_AREA_RELOAD_INDEX = 6,
     SV_CURSOR_COLOR_INDEX = 7,
+    SV_COMMANDS = 8,
 };
 
 struct GZSaveHeader {
@@ -35,6 +36,7 @@ struct GZSaveLayout {
     Scene::SceneItem SceneItems[SCENE_AMNT];
     MemoryWatch Watches[MAX_WATCHES];
     Vec2 sprite_offsets[SPRITES_AMNT];
+    bool commands_states[COMMANDS_AMNT];
     bool g_drop_shadows;
     int g_area_reload_behavior;
     int g_cursor_color;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -15,6 +15,8 @@ bool reload_area_flag = false;
 bool timer_started = false;
 bool reset_timer = false;
 
+bool commands_states[COMMANDS_AMNT];
+
 namespace Commands {
     static float saved_x = 0.0f;
     static float saved_y = 0.0f;
@@ -89,20 +91,20 @@ namespace Commands {
     }
 
     struct Command {
-        bool active;
+        bool& active;
         uint16_t buttons;
         void (*command)();
     };
 
-    static Command Commands[8] = {
-        {false, 0x0028, store_position},
-        {false, 0x0024, load_position},
-        {false, 0x0120, moon_jump},
-        {false, 0x1160, reload_area},
-        {false, 0x0110, toggle_timer},
-        {false, 0x0210, hit_reset},
-        {false, 0x0050, gorge_void},
-        {false, 0x0310, toggle_free_cam}};
+    static Command Commands[COMMANDS_AMNT] = {
+        {commands_states[CMD_STORE_POSITION], 0x0028, store_position},
+        {commands_states[CMD_LOAD_POSITION], 0x0024, load_position},
+        {commands_states[CMD_MOON_JUMP], 0x0120, moon_jump},
+        {commands_states[CMD_RELOAD_AREA], 0x1160, reload_area},
+        {commands_states[CMD_TIMER_TOGGLE], 0x0110, toggle_timer},
+        {commands_states[CMD_TIMER_RESET], 0x0210, hit_reset},
+        {commands_states[CMD_GORGE_VOID], 0x0050, gorge_void},
+        {commands_states[CMD_FREE_CAM], 0x0310, toggle_free_cam}};
 
     void process_inputs() {
         button_this_frame = tp_mPadStatus.sval;

--- a/src/menus/cheat_menu.cpp
+++ b/src/menus/cheat_menu.cpp
@@ -61,7 +61,7 @@ namespace Cheats {
             if (cheat.active) {
                 switch (cheat.id) {
                     case MoonJump: {
-                        Commands::enable_command(Commands::MOON_JUMP);
+                        Commands::enable_command(Commands::CMD_MOON_JUMP);
                         break;
                     }
                     case Invincible: {
@@ -119,7 +119,7 @@ namespace Cheats {
             } else {
                 switch (cheat.id) {
                     case MoonJump: {
-                        Commands::disable_command(Commands::MOON_JUMP);
+                        Commands::disable_command(Commands::CMD_MOON_JUMP);
                         break;
                     }
                     case SuperClawshot: {

--- a/src/menus/tools_menu.cpp
+++ b/src/menus/tools_menu.cpp
@@ -94,34 +94,34 @@ void ToolsMenu::render(Font& font) {
         if (ToolItems[cursor.y].active) {
             switch (cursor.y) {
                 case TIMER_INDEX: {
-                    Commands::enable_command(Commands::TIMER_TOGGLE);
-                    Commands::enable_command(Commands::TIMER_RESET);
+                    Commands::enable_command(Commands::CMD_TIMER_TOGGLE);
+                    Commands::enable_command(Commands::CMD_TIMER_RESET);
                     break;
                 }
                 case LOAD_TIMER_INDEX: {
-                    Commands::enable_command(Commands::TIMER_RESET);
+                    Commands::enable_command(Commands::CMD_TIMER_RESET);
                     break;
                 }
                 case IGT_TIMER_INDEX: {
-                    Commands::enable_command(Commands::TIMER_TOGGLE);
-                    Commands::enable_command(Commands::TIMER_RESET);
+                    Commands::enable_command(Commands::CMD_TIMER_TOGGLE);
+                    Commands::enable_command(Commands::CMD_TIMER_RESET);
                     break;
                 }
                 case GORGE_INDEX: {
                     if (ToolItems[GORGE_INDEX].active) {
-                        Commands::enable_command(Commands::GORGE_VOID);
+                        Commands::enable_command(Commands::CMD_GORGE_VOID);
                     } else {
-                        Commands::disable_command(Commands::GORGE_VOID);
+                        Commands::disable_command(Commands::CMD_GORGE_VOID);
                     }
                     break;
                 }
                 case TELEPORT_INDEX: {
-                    Commands::enable_command(Commands::STORE_POSITION);
-                    Commands::enable_command(Commands::LOAD_POSITION);
+                    Commands::enable_command(Commands::CMD_STORE_POSITION);
+                    Commands::enable_command(Commands::CMD_LOAD_POSITION);
                     break;
                 }
                 case RELOAD_AREA_INDEX: {
-                    Commands::enable_command(Commands::RELOAD_AREA);
+                    Commands::enable_command(Commands::CMD_RELOAD_AREA);
                     break;
                 }
                 case FAST_MOVEMENT_INDEX: {
@@ -152,7 +152,7 @@ void ToolsMenu::render(Font& font) {
                     break;
                 }
                 case FREE_CAM_INDEX: {
-                    Commands::enable_command(Commands::FREE_CAM);
+                    Commands::enable_command(Commands::CMD_FREE_CAM);
                     free_cam_active = false;
                     break;
                 }
@@ -163,12 +163,12 @@ void ToolsMenu::render(Font& font) {
         } else {
             switch (cursor.y) {
                 case TELEPORT_INDEX: {
-                    Commands::disable_command(Commands::STORE_POSITION);
-                    Commands::disable_command(Commands::LOAD_POSITION);
+                    Commands::disable_command(Commands::CMD_STORE_POSITION);
+                    Commands::disable_command(Commands::CMD_LOAD_POSITION);
                     break;
                 }
                 case RELOAD_AREA_INDEX: {
-                    Commands::disable_command(Commands::RELOAD_AREA);
+                    Commands::disable_command(Commands::CMD_RELOAD_AREA);
                     break;
                 }
                 case FAST_MOVEMENT_INDEX: {
@@ -195,7 +195,7 @@ void ToolsMenu::render(Font& font) {
                     break;
                 }
                 case FREE_CAM_INDEX: {
-                    Commands::disable_command(Commands::FREE_CAM);
+                    Commands::disable_command(Commands::CMD_FREE_CAM);
                     free_cam_active = false;
                     break;
                 }

--- a/src/utils/card.cpp
+++ b/src/utils/card.cpp
@@ -2,6 +2,7 @@
 #include "libtp_c/include/system.h"
 #include "libtp_c/include/math.h"
 #include "saves.h"
+#include "commands.h"
 #include "fifo_queue.h"
 
 namespace Utilities {
@@ -54,6 +55,7 @@ namespace Utilities {
         tp_memcpy(save_layout.SceneItems, SceneItems, sizeof(SceneItems));
         tp_memcpy(save_layout.Watches, Watches, sizeof(Watches));
         tp_memcpy(save_layout.sprite_offsets, sprite_offsets, sizeof(sprite_offsets));
+        tp_memcpy(save_layout.commands_states, commands_states, sizeof(commands_states));
         save_layout.g_drop_shadows = g_drop_shadows;
         save_layout.g_area_reload_behavior = g_area_reload_behavior;
         save_layout.g_cursor_color = g_cursor_color;
@@ -65,6 +67,7 @@ namespace Utilities {
         tp_memcpy(SceneItems, save_layout.SceneItems, sizeof(SceneItems));
         tp_memcpy(Watches, save_layout.Watches, sizeof(Watches));
         tp_memcpy(sprite_offsets, save_layout.sprite_offsets, sizeof(sprite_offsets));
+        tp_memcpy(commands_states, save_layout.commands_states, sizeof(commands_states));
         g_drop_shadows = save_layout.g_drop_shadows;
         g_area_reload_behavior = save_layout.g_area_reload_behavior;
         g_cursor_color = save_layout.g_cursor_color;
@@ -84,6 +87,7 @@ namespace Utilities {
         set_entry(SV_SCENE_INDEX, SceneItems);
         set_entry(SV_WATCHES_INDEX, Watches);
         set_entry(SV_SPRITES_INDEX, sprite_offsets);
+        set_entry(SV_COMMANDS, commands_states);
         set_entry(SV_DROP_SHADOW_INDEX, g_drop_shadows);
         set_entry(SV_AREA_RELOAD_INDEX, g_area_reload_behavior);
         set_entry(SV_CURSOR_COLOR_INDEX, g_cursor_color);
@@ -115,6 +119,7 @@ namespace Utilities {
         assert_read_entry(SV_SCENE_INDEX, save_file.data.SceneItems, sizeof(save_file.data.SceneItems));
         assert_read_entry(SV_WATCHES_INDEX, save_file.data.Watches, sizeof(save_file.data.Watches));
         assert_read_entry(SV_SPRITES_INDEX, save_file.data.sprite_offsets, sizeof(save_file.data.sprite_offsets));
+        assert_read_entry(SV_COMMANDS, save_file.data.commands_states, sizeof(save_file.data.commands_states));
         assert_read_entry(SV_DROP_SHADOW_INDEX, &save_file.data.g_drop_shadows, sizeof(save_file.data.g_drop_shadows));
         assert_read_entry(SV_AREA_RELOAD_INDEX, &save_file.data.g_area_reload_behavior, sizeof(save_file.data.g_area_reload_behavior));
         assert_read_entry(SV_CURSOR_COLOR_INDEX, &save_file.data.g_cursor_color, sizeof(save_file.data.g_cursor_color));

--- a/src/utils/card.cpp
+++ b/src/utils/card.cpp
@@ -12,6 +12,7 @@ namespace Utilities {
     int32_t card_write(CardInfo* card_info, void* data, int32_t size, int32_t offset, int32_t sector_size) {
         uint8_t* buf = (uint8_t*)tp_memalign(-32, sector_size);
         int32_t result = Ready;
+        int32_t read_bytes = 0;
 
         while (result == Ready && size > 0) {
             result = CARDRead(card_info, buf, sector_size, (offset & ~(sector_size - 1)));
@@ -19,8 +20,9 @@ namespace Utilities {
                 break;
             }
             int32_t rem_size = sector_size - (offset & (sector_size - 1));
-            tp_memcpy(buf + (offset & (sector_size - 1)), data, MIN(rem_size, size));
+            tp_memcpy(buf + (offset & (sector_size - 1)), (void*)((uint32_t)data + read_bytes), MIN(rem_size, size));
             result = CARDWrite(card_info, buf, sector_size, (offset & ~(sector_size - 1)));
+            read_bytes += MIN(rem_size, size);
             size -= rem_size;
             offset += rem_size;
         }
@@ -34,6 +36,7 @@ namespace Utilities {
     int32_t card_read(CardInfo* card_info, void* data, int32_t size, int32_t offset, int32_t sector_size) {
         uint8_t* buf = (uint8_t*)tp_memalign(-32, sector_size);
         int32_t result = Ready;
+        int32_t read_bytes = 0;
 
         while (result == Ready && size > 0) {
             result = CARDRead(card_info, buf, sector_size, (offset & ~(sector_size - 1)));
@@ -41,7 +44,8 @@ namespace Utilities {
                 break;
             }
             int32_t rem_size = sector_size - (offset & (sector_size - 1));
-            tp_memcpy(data, buf + (offset & (sector_size - 1)), MIN(rem_size, size));
+            tp_memcpy((void*)((uint32_t)data + read_bytes), buf + (offset & (sector_size - 1)), MIN(rem_size, size));
+            read_bytes += MIN(rem_size, size);
             size -= rem_size;
             offset += rem_size;
         }

--- a/src/utils/card.cpp
+++ b/src/utils/card.cpp
@@ -19,7 +19,7 @@ namespace Utilities {
                 break;
             }
             int32_t rem_size = sector_size - (offset & (sector_size - 1));
-            tp_memcpy(buf + (offset & (sector_size - 1)), data, size > rem_size ? rem_size : size);
+            tp_memcpy(buf + (offset & (sector_size - 1)), data, MIN(rem_size, size));
             result = CARDWrite(card_info, buf, sector_size, (offset & ~(sector_size - 1)));
             size -= rem_size;
             offset += rem_size;
@@ -41,7 +41,7 @@ namespace Utilities {
                 break;
             }
             int32_t rem_size = sector_size - (offset & (sector_size - 1));
-            tp_memcpy(data, buf + (offset & (sector_size - 1)), size > rem_size ? rem_size : size);
+            tp_memcpy(data, buf + (offset & (sector_size - 1)), MIN(rem_size, size));
             size -= rem_size;
             offset += rem_size;
         }
@@ -133,8 +133,9 @@ namespace Utilities {
         GZSaveFile save_file;
         Utilities::setup_save_file(save_file);
         Utilities::store_save_layout(save_file.data);
+        uint32_t file_size = (uint32_t)(tp_ceil((double)sizeof(save_file) / (double)card.sector_size) * card.sector_size);
         card.card_result = CARDDelete(0, card.file_name_buffer);
-        card.card_result = CARDCreate(0, card.file_name_buffer, card.sector_size, &card.card_info);
+        card.card_result = CARDCreate(0, card.file_name_buffer, file_size, &card.card_info);
         if (card.card_result == Ready || card.card_result == Exist) {
             card.card_result = CARDOpen(0, card.file_name_buffer, &card.card_info);
             if (card.card_result == Ready) {


### PR DESCRIPTION
Even if the teleport tool (or other tool/cheat using commands) was saved, the commands would not be loaded, and thus would not work until re-enabling the tool/cheat.