### PR TITLE
made target name consistent regardless of folder name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ include $(DEVKITPPC)/gamecube_rules
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	$(notdir $(CURDIR))
+TARGET		:=	tpgz
 BUILD		:=	build
 SOURCES		:=	src src/fonts src/utils src/menus
 EXTERNAL    :=  external


### PR DESCRIPTION
Since I'm using my wii fork (tpgzw) to make those PRs, I'm tired to always have to rename the `tpgzw.a` file every time I want to patch the iso. It also makes more sense to have the name of the library be consistent, regardless of the folder's name, since it's used in RomHack.toml